### PR TITLE
Publish gripper joint state from hardware interface

### DIFF
--- a/xarm_api/include/xarm_api/xarm_driver.h
+++ b/xarm_api/include/xarm_api/xarm_driver.h
@@ -86,6 +86,8 @@ namespace xarm_api
 
         bool is_connected(void);
 
+        sensor_msgs::JointState getGripperJointStates();
+
     private:
         void _report_connect_changed_callback(bool connected, bool reported);
         void _report_data_callback(XArmReportData *report_data_ptr);

--- a/xarm_api/include/xarm_api/xarm_driver.h
+++ b/xarm_api/include/xarm_api/xarm_driver.h
@@ -18,7 +18,7 @@ namespace xarm_api
     public:
         XArmDriver():spinner_(4){ spinner_.start(); };
         ~XArmDriver();
-        void init(ros::NodeHandle& root_nh, std::string &server_ip);
+        void init(ros::NodeHandle& root_nh, std::string& server_ip, bool publish_joint_states=true);
 
         // provide a list of services:
         bool MotionCtrlCB(xarm_msgs::SetAxis::Request &req, xarm_msgs::SetAxis::Response &res);
@@ -124,6 +124,7 @@ namespace xarm_api
         float init_gripper_pos_;
         bool gripper_init_loop_;
         bool gripper_added_;
+        bool publish_joint_states_;
 
         ros::NodeHandle nh_;
         ros::ServiceServer go_home_server_;

--- a/xarm_api/src/xarm_driver.cpp
+++ b/xarm_api/src/xarm_driver.cpp
@@ -212,7 +212,8 @@ namespace xarm_api
         xarm_state_msg_.angle.resize(dof_);
 
         // state feedback topics:
-        joint_state_ = nh_.advertise<sensor_msgs::JointState>("joint_states", 10, true);
+        if(publish_joint_states_)
+            joint_state_ = nh_.advertise<sensor_msgs::JointState>("joint_states", 10, true);
         robot_rt_state_ = nh_.advertise<xarm_msgs::RobotMsg>("xarm_states", 10, true);
         cgpio_state_ = nh_.advertise<xarm_msgs::CIOState>("xarm_cgpio_states", 10, true);
         // ftsensor_state_ = nh_.advertise<geometry_msgs::WrenchStamped>("xarm_ftsensor_states", 10, true);
@@ -236,10 +237,11 @@ namespace xarm_api
         nh_.getParam("xarm_report_type", report_type_);
     }
 
-    void XArmDriver::init(ros::NodeHandle& root_nh, std::string &server_ip)
-    {   
+    void XArmDriver::init(ros::NodeHandle& root_nh, std::string &server_ip, bool publish_joint_states)
+    {
+        publish_joint_states_ = publish_joint_states;
         nh_ = root_nh;
-        
+
         bool baud_checkset = true;
         if (nh_.hasParam("baud_checkset")) {
             nh_.getParam("baud_checkset", baud_checkset);
@@ -1325,7 +1327,8 @@ namespace xarm_api
     
     void XArmDriver::pub_joint_state(sensor_msgs::JointState &js_msg)
     {
-        joint_state_.publish(js_msg);
+        if(publish_joint_states_)
+            joint_state_.publish(js_msg);
     }
 
     void XArmDriver::pub_cgpio_state(xarm_msgs::CIOState &cio_msg)

--- a/xarm_api/src/xarm_driver.cpp
+++ b/xarm_api/src/xarm_driver.cpp
@@ -361,6 +361,11 @@ namespace xarm_api
         pub_joint_state(gripper_joint_state_msg_);
     }
 
+    sensor_msgs::JointState XArmDriver::getGripperJointStates()
+    {
+        return gripper_joint_state_msg_;
+    }
+
     void XArmDriver::_handle_gripper_action_goal(actionlib::ActionServer<control_msgs::GripperCommandAction>::GoalHandle gh)
     {
         gripper_init_loop_ = true;

--- a/xarm_api/src/xarm_driver.cpp
+++ b/xarm_api/src/xarm_driver.cpp
@@ -324,11 +324,13 @@ namespace xarm_api
         gripper_joint_state_msg_.name[3] = "right_outer_knuckle_joint";
         gripper_joint_state_msg_.name[4] = "right_finger_joint";
         gripper_joint_state_msg_.name[5] = "right_inner_knuckle_joint";
-        gripper_action_server_.reset(new actionlib::ActionServer<control_msgs::GripperCommandAction>(gripper_node, "gripper_action",
-          std::bind(&XArmDriver::_handle_gripper_action_goal, this, std::placeholders::_1),
-          std::bind(&XArmDriver::_handle_gripper_action_cancel, this, std::placeholders::_1),
-          false));
-        gripper_action_server_->start(); 
+        if(gripper_added_){
+            gripper_action_server_.reset(new actionlib::ActionServer<control_msgs::GripperCommandAction>(gripper_node, "gripper_action",
+            std::bind(&XArmDriver::_handle_gripper_action_goal, this, std::placeholders::_1),
+            std::bind(&XArmDriver::_handle_gripper_action_cancel, this, std::placeholders::_1),
+            false));
+            gripper_action_server_->start();
+        }
 
         bool add_gripper = false;
         gripper_added_ = false;

--- a/xarm_controller/include/xarm_controller/xarm_hw.h
+++ b/xarm_controller/include/xarm_controller/xarm_hw.h
@@ -72,6 +72,7 @@ namespace xarm_control
 		int curr_err_;
 		int read_code_;
 		int write_code_;
+		bool has_gripper_;
 
 		unsigned int dof_;
 		std::vector<std::string> jnt_names_;


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary

xarm_driverが独自にarmとgripperのjoint_statesをpublishしていたのを、
hardware interfaceからxarm_driverを使う場合にはhardware interface経由でjoint_statesをpublishできるようにしました。

<!-- このPull Requestで解決されるIssue
fix #issue番号 の形式で記述
fix以外のkeywordはこちら。(https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) -->
- fix #13 

<!-- 変更の詳細 -->
## Detail

<!-- この関数を変更したのでこの機能にも影響がある、など -->
## Impact

<!-- どのような動作検証を行ったか -->
## Test
<!-- ROS package向け Template -->
  <!-- * [ ] gazebo環境で起動した
    * [ ] cuboid
    * [ ] signage
  * [ ] 実機環境で起動した
    * [ ] cuboid
    * [ ] signage
  * [ ] (アプリ名)で動作検証した -->

## Attention
<!-- 上記項目以外の補足情報など
例
- レビューをする際に見てほしい点
- ローカル環境で試す際の注意点
- このPull Requestよりも先にマージしなければならないPull Request
- 複数レビュワー指定している場合に、レビュー必須の人(いれば)の指定 -->
