### PR TITLE
limit graspablity

### DIFF
--- a/xarm_gripper/urdf/xarm_gripper.urdf.xacro
+++ b/xarm_gripper/urdf/xarm_gripper.urdf.xacro
@@ -105,7 +105,7 @@
     <limit
       lower="0"
       upper="0.85"
-      effort="50"
+      effort="1.0"
       velocity="2" />
     <dynamics
       damping="1.0"
@@ -181,9 +181,9 @@
       upper="0.85"
       effort="50"
       velocity="2" />
-    <dynamics
-      damping="1.0"
-      friction="0" />
+    <!--<dynamics-->
+    <!--  damping="1.0"-->
+    <!--  friction="0" />-->
     <mimic joint="${prefix}drive_joint" multiplier="1" offset="0" />
   </joint>
   <link
@@ -240,9 +240,9 @@
       upper="0.85"
       effort="50"
       velocity="2" />
-    <dynamics
-      damping="1.0"
-      friction="0" />
+    <!--<dynamics-->
+    <!--  damping="1.0"-->
+    <!--  friction="0" />-->
     <mimic joint="${prefix}drive_joint" multiplier="1" offset="0" />
   </joint>
 
@@ -256,16 +256,16 @@
           <xyz>1 0 0</xyz>
           <use_parent_model_frame>false</use_parent_model_frame>
         </axis>
-        <physics>
-          <ode>
-            <implicit_spring_damper>1</implicit_spring_damper>
-            <cfm_damping>0</cfm_damping>
-            <limit>
-              <cfm>1e-7</cfm>
-              <erp>0.8</erp>
-            </limit>
-          </ode>
-        </physics>
+        <!--<physics>-->
+        <!--  <ode>-->
+        <!--    <implicit_spring_damper>1</implicit_spring_damper>-->
+        <!--    <cfm_damping>0</cfm_damping>-->
+        <!--    <limit>-->
+        <!--      <cfm>1e-7</cfm>-->
+        <!--      <erp>0.8</erp>-->
+        <!--    </limit>-->
+        <!--  </ode>-->
+        <!--</physics>-->
       </joint>
     </gazebo>
   </xacro:if>
@@ -324,9 +324,9 @@
       upper="0.85"
       effort="50"
       velocity="2" />
-    <dynamics
-      damping="1.0"
-      friction="0" />
+    <!--<dynamics-->
+    <!--  damping="1.0"-->
+    <!--  friction="0" />-->
     <mimic joint="${prefix}drive_joint" multiplier="1" offset="0" />
   </joint>
   <link
@@ -399,9 +399,9 @@
       upper="0.85"
       effort="50"
       velocity="2" />
-    <dynamics
-      damping="1.0"
-      friction="0" />
+    <!--<dynamics-->
+    <!--  damping="1.0"-->
+    <!--  friction="0" />-->
     <mimic joint="${prefix}drive_joint" multiplier="1" offset="0" />
   </joint>
   <link
@@ -456,36 +456,36 @@
     <limit
       lower="0"
       upper="0.85"
-      effort="50"
+      effort="0.5"
       velocity="2" />
-    <dynamics
-      damping="1.0"
-      friction="0" />
+    <!--<dynamics-->
+    <!--  damping="1.0"-->
+    <!--  friction="0" />-->
     <mimic joint="${prefix}drive_joint" multiplier="1" offset="0" />
   </joint>
 
   <xacro:if value="${loop_joints}">
-    <gazebo> 
-      <joint name="${prefix}right_loop_joint" type="revolute"> 
-        <parent>${prefix}right_inner_knuckle</parent> 
-        <child>${prefix}right_finger</child> 
-        <pose>0 0.015 0.015 0 0 0</pose> 
-        <axis> 
-          <xyz>1 0 0</xyz> 
-          <use_parent_model_frame>false</use_parent_model_frame> 
-        </axis> 
-        <physics> 
-          <ode> 
-            <implicit_spring_damper>1</implicit_spring_damper> 
-            <cfm_damping>0</cfm_damping> 
-            <limit> 
-              <cfm>1e-7</cfm> 
-              <erp>0.8</erp> 
-            </limit> 
-          </ode> 
-        </physics> 
-      </joint> 
-    </gazebo> 
+    <gazebo>
+      <joint name="${prefix}right_loop_joint" type="revolute">
+        <parent>${prefix}right_inner_knuckle</parent>
+        <child>${prefix}right_finger</child>
+        <pose>0 0.015 0.015 0 0 0</pose>
+        <axis>
+          <xyz>1 0 0</xyz>
+          <use_parent_model_frame>false</use_parent_model_frame>
+        </axis>
+        <!--<physics>-->
+        <!--  <ode>-->
+        <!--    <implicit_spring_damper>1</implicit_spring_damper>-->
+        <!--    <cfm_damping>0</cfm_damping>-->
+        <!--    <limit>-->
+        <!--      <cfm>1e-7</cfm>-->
+        <!--      <erp>0.8</erp>-->
+        <!--    </limit>-->
+        <!--  </ode>-->
+        <!--</physics>-->
+      </joint>
+    </gazebo>
   </xacro:if>
 
   <link name="${prefix}link_tcp" />


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary

<!-- このPull Requestで解決されるIssue
fix #issue番号 の形式で記述
fix以外のkeywordはこちら。(https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) -->
- fix #18 


![Screenshot from 2023-06-08 15-03-30](https://github.com/sbgisen/xarm_ros/assets/7608312/1d4ba907-c6a6-4c97-9821-d7fc06ae0333)

- Product slip is not considered here; that is an issue for private_gazebo_models repository.
- The downside of this feature is that the gripper will not close entirely when grasping an object. That means the gripper controller will return failure status for closing gripper and the current gripper status will be reflected on the joint states which will have impact on the PlanningScene (for example, the unclosed gripper may collide with other objects)

<!-- 変更の詳細 -->
## Detail

<!-- この関数を変更したのでこの機能にも影響がある、など -->
## Impact

<!-- どのような動作検証を行ったか -->
## Test
<!-- ROS package向け Template -->
  <!-- * [ ] gazebo環境で起動した
    * [ ] cuboid
    * [ ] signage
  * [ ] 実機環境で起動した
    * [ ] cuboid
    * [ ] signage
  * [ ] (アプリ名)で動作検証した -->

## Attention
<!-- 上記項目以外の補足情報など
例
- レビューをする際に見てほしい点
- ローカル環境で試す際の注意点
- このPull Requestよりも先にマージしなければならないPull Request
- 複数レビュワー指定している場合に、レビュー必須の人(いれば)の指定 -->
- While this PR resolves #18, the issue itself is not too crucial, as fixing this issue will only improve simulation appearance (and maybe, to an extent, grasp physics, but that is yet to be seen). If the downside stated above is too heavy to ignore, then either we close this PR or create our own gazebo-custom gripper controller