### PR TITLE
Feature/cable collision

### DIFF
--- a/xarm_gripper/urdf/xarm_gripper.urdf.xacro
+++ b/xarm_gripper/urdf/xarm_gripper.urdf.xacro
@@ -1,514 +1,514 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro" name="xarm_gripper">
-<!--
+  <!--
   Author: Jason Peng <jason@ufactory.cc>
 -->
   <xacro:macro name="xarm_gripper_urdf" params="prefix:='' attach_to:='' rpy:='0 0 0' xyz:='0 0 0' loop_joints:='false' ">
-  <xacro:unless value="${attach_to == ''}">
-    <joint name="${prefix}gripper_fix" type="fixed">
-      <parent link="${attach_to}"/>
-      <child link="${prefix}xarm_gripper_base_link"/>
-      <origin xyz="${xyz}" rpy="${rpy}"/>
-    </joint>
-  </xacro:unless>
-  <link
-    name="${prefix}xarm_gripper_base_link">
-    <inertial>
-      <origin
-        xyz="-0.00065489 -0.0018497 0.048028"
-        rpy="0 0 0" />
-      <mass
-        value="0.54156" />
-      <inertia
-        ixx="0.00047106"
-        ixy="3.9292E-07"
-        ixz="2.6537E-06"
-        iyy="0.00033072"
-        iyz="-1.0975E-05"
-        izz="0.00025642" />
-    </inertial>
-    <visual>
-      <origin
-        xyz="0 0 0"
-        rpy="0 0 0" />
-      <geometry>
-        <mesh
-          filename="package://xarm_gripper/meshes/base_link.STL" />
-      </geometry>
-      <!-- <material
+    <xacro:unless value="${attach_to == ''}">
+      <joint name="${prefix}gripper_fix" type="fixed">
+        <parent link="${attach_to}"/>
+        <child link="${prefix}xarm_gripper_base_link"/>
+        <origin xyz="${xyz}" rpy="${rpy}"/>
+      </joint>
+    </xacro:unless>
+    <link
+      name="${prefix}xarm_gripper_base_link">
+      <inertial>
+        <origin
+          xyz="-0.00065489 -0.0018497 0.048028"
+          rpy="0 0 0"/>
+        <mass
+          value="0.54156"/>
+        <inertia
+          ixx="0.00047106"
+          ixy="3.9292E-07"
+          ixz="2.6537E-06"
+          iyy="0.00033072"
+          iyz="-1.0975E-05"
+          izz="0.00025642"/>
+      </inertial>
+      <visual>
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0"/>
+        <geometry>
+          <mesh
+            filename="package://xarm_gripper/meshes/base_link.STL"/>
+        </geometry>
+        <!-- <material
         name="">
         <color
           rgba="0.89804 0.91765 0.92941 1" />
       </material> -->
-      <material name="White">
-        <color rgba="1.0 1.0 1.0 1.0"/>
-      </material>
-    </visual>
-    <collision>
+        <material name="White">
+          <color rgba="1.0 1.0 1.0 1.0"/>
+        </material>
+      </visual>
+      <collision>
+        <origin
+          xyz="-0.0015 0 0.055"
+          rpy="0 0 0"/>
+        <geometry>
+          <box size="0.053 0.1 0.1"/>
+        </geometry>
+      </collision>
+      <collision>
+        <origin
+          xyz="0.03 -0.062 0.025"
+          rpy="0 0 0"/>
+        <geometry>
+          <box size="0.076 0.024 0.04"/>
+        </geometry>
+      </collision>
+    </link>
+    <link
+      name="${prefix}left_outer_knuckle">
+      <inertial>
+        <origin
+          xyz="2.9948E-14 0.021559 0.015181"
+          rpy="0 0 0"/>
+        <mass
+          value="0.033618"/>
+        <inertia
+          ixx="1.9111E-05"
+          ixy="-1.8803E-17"
+          ixz="-1.1002E-17"
+          iyy="6.6256E-06"
+          iyz="-7.3008E-06"
+          izz="1.3185E-05"/>
+      </inertial>
+      <visual>
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0"/>
+        <geometry>
+          <mesh
+            filename="package://xarm_gripper/meshes/left_outer_knuckle.STL"/>
+        </geometry>
+        <material name="Silver">
+          <color rgba="0.753 0.753 0.753 1.0"/>
+        </material>
+      </visual>
+      <collision>
+        <origin
+          xyz="0 0.015 0.02"
+          rpy="0.48 0 0"/>
+        <geometry>
+          <box size="0.012 0.069 0.033"/>
+        </geometry>
+      </collision>
+    </link>
+    <joint
+      name="${prefix}drive_joint"
+      type="revolute">
       <origin
-        xyz="-0.0015 0 0.055"
-        rpy="0 0 0" />
-      <geometry>
-        <box size="0.053 0.1 0.1"/>
-      </geometry>
-    </collision>
-    <collision>
+        xyz="0 0.035 0.059098"
+        rpy="0 0 0"/>
+      <parent
+        link="${prefix}xarm_gripper_base_link"/>
+      <child
+        link="${prefix}left_outer_knuckle"/>
+      <axis
+        xyz="1 0 0"/>
+      <limit
+        lower="0"
+        upper="0.85"
+        effort="1.0"
+        velocity="2"/>
+      <dynamics
+        damping="1.0"
+        friction="0"/>
+    </joint>
+    <link
+      name="${prefix}left_finger">
+      <inertial>
+        <origin
+          xyz="-2.4536E-14 -0.016413 0.029258"
+          rpy="0 0 0"/>
+        <mass
+          value="0.048304"/>
+        <inertia
+          ixx="1.7493E-05"
+          ixy="-4.2156E-19"
+          ixz="6.9164E-18"
+          iyy="1.7225E-05"
+          iyz="4.6433E-06"
+          izz="5.1466E-06"/>
+      </inertial>
+      <visual>
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0"/>
+        <geometry>
+          <mesh
+            filename="package://xarm_gripper/meshes/left_finger.STL"/>
+        </geometry>
+        <material name="Silver">
+          <color rgba="0.753 0.753 0.753 1.0"/>
+        </material>
+      </visual>
+      <collision>
+        <origin
+          xyz="0 -0.0224 0.04"
+          rpy="0 0 0"/>
+        <geometry>
+          <box size="0.032 0.0072 0.042"/>
+        </geometry>
+      </collision>
+      <collision>
+        <origin
+          xyz="0 -0.0154 0.036"
+          rpy="0 0 0"/>
+        <geometry>
+          <box size="0.032 0.0068 0.034"/>
+        </geometry>
+      </collision>
+      <collision>
+        <origin
+          xyz="0 -0.008 0.008"
+          rpy="0.8 0 0"/>
+        <geometry>
+          <box size="0.016 0.012 0.036"/>
+        </geometry>
+      </collision>
+    </link>
+    <joint
+      name="${prefix}left_finger_joint"
+      type="revolute">
       <origin
-        xyz="0.03 -0.062 0.025"
-        rpy="0 0 0" />
-      <geometry>
-        <box size="0.076 0.024 0.04"/>
-      </geometry>
-    </collision>
-  </link>
-  <link
-    name="${prefix}left_outer_knuckle">
-    <inertial>
+        xyz="0 0.035465 0.042039"
+        rpy="0 0 0"/>
+      <parent
+        link="${prefix}left_outer_knuckle"/>
+      <child
+        link="${prefix}left_finger"/>
+      <axis
+        xyz="-1 0 0"/>
+      <limit
+        lower="0"
+        upper="0.85"
+        effort="50"
+        velocity="2"/>
+      <!--<dynamics-->
+      <!--  damping="1.0"-->
+      <!--  friction="0" />-->
+      <mimic joint="${prefix}drive_joint" multiplier="1" offset="0"/>
+    </joint>
+    <link
+      name="${prefix}left_inner_knuckle">
+      <inertial>
+        <origin
+          xyz="1.86600784687907E-06 0.0220467847633621 0.0261334672830885"
+          rpy="0 0 0"/>
+        <mass
+          value="0.0230125781256706"/>
+        <inertia
+          ixx="6.09490024271906E-06"
+          ixy="6.06651326160071E-11"
+          ixz="7.19102670500635E-11"
+          iyy="6.01955084375188E-06"
+          iyz="-2.75316812991721E-06"
+          izz="5.07862004479903E-06"/>
+      </inertial>
+      <visual>
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0"/>
+        <geometry>
+          <mesh
+            filename="package://xarm_gripper/meshes/left_inner_knuckle.STL"/>
+        </geometry>
+        <material name="Silver">
+          <color rgba="0.753 0.753 0.753 1.0"/>
+        </material>
+      </visual>
+      <collision>
+        <origin
+          xyz="0 0.016 0.02"
+          rpy="-0.7 0 0"/>
+        <geometry>
+          <box size="0.027 0.012 0.061"/>
+        </geometry>
+      </collision>
+    </link>
+    <joint
+      name="${prefix}left_inner_knuckle_joint"
+      type="revolute">
       <origin
-        xyz="2.9948E-14 0.021559 0.015181"
-        rpy="0 0 0" />
-      <mass
-        value="0.033618" />
-      <inertia
-        ixx="1.9111E-05"
-        ixy="-1.8803E-17"
-        ixz="-1.1002E-17"
-        iyy="6.6256E-06"
-        iyz="-7.3008E-06"
-        izz="1.3185E-05" />
-    </inertial>
-    <visual>
-      <origin
-        xyz="0 0 0"
-        rpy="0 0 0" />
-      <geometry>
-        <mesh
-          filename="package://xarm_gripper/meshes/left_outer_knuckle.STL" />
-      </geometry>
-      <material name="Silver">
-        <color rgba="0.753 0.753 0.753 1.0"/>
-      </material>
-    </visual>
-    <collision>
-      <origin
-        xyz="0 0.015 0.02"
-        rpy="0.48 0 0" />
-      <geometry>
-        <box size="0.012 0.069 0.033"/>
-      </geometry>
-    </collision>
-  </link>
-  <joint
-    name="${prefix}drive_joint"
-    type="revolute">
-    <origin
-      xyz="0 0.035 0.059098"
-      rpy="0 0 0" />
-    <parent
-      link="${prefix}xarm_gripper_base_link" />
-    <child
-      link="${prefix}left_outer_knuckle" />
-    <axis
-      xyz="1 0 0" />
-    <limit
-      lower="0"
-      upper="0.85"
-      effort="1.0"
-      velocity="2" />
-    <dynamics
-      damping="1.0"
-      friction="0" />
-  </joint>
-  <link
-    name="${prefix}left_finger">
-    <inertial>
-      <origin
-        xyz="-2.4536E-14 -0.016413 0.029258"
-        rpy="0 0 0" />
-      <mass
-        value="0.048304" />
-      <inertia
-        ixx="1.7493E-05"
-        ixy="-4.2156E-19"
-        ixz="6.9164E-18"
-        iyy="1.7225E-05"
-        iyz="4.6433E-06"
-        izz="5.1466E-06" />
-    </inertial>
-    <visual>
-      <origin
-        xyz="0 0 0"
-        rpy="0 0 0" />
-      <geometry>
-        <mesh
-          filename="package://xarm_gripper/meshes/left_finger.STL" />
-      </geometry>
-      <material name="Silver">
-        <color rgba="0.753 0.753 0.753 1.0"/>
-      </material>
-    </visual>
-    <collision>
-      <origin
-        xyz="0 -0.0224 0.04"
-        rpy="0 0 0" />
-      <geometry>
-        <box size="0.032 0.0072 0.042"/>
-      </geometry>
-    </collision>
-    <collision>
-      <origin
-        xyz="0 -0.0154 0.036"
-        rpy="0 0 0" />
-      <geometry>
-        <box size="0.032 0.0068 0.034"/>
-      </geometry>
-    </collision>
-    <collision>
-      <origin
-        xyz="0 -0.008 0.008"
-        rpy="0.8 0 0" />
-      <geometry>
-        <box size="0.016 0.012 0.036"/>
-      </geometry>
-    </collision>
-  </link>
-  <joint
-    name="${prefix}left_finger_joint"
-    type="revolute">
-    <origin
-      xyz="0 0.035465 0.042039"
-      rpy="0 0 0" />
-    <parent
-      link="${prefix}left_outer_knuckle" />
-    <child
-      link="${prefix}left_finger" />
-    <axis
-      xyz="-1 0 0" />
-    <limit
-      lower="0"
-      upper="0.85"
-      effort="50"
-      velocity="2" />
-    <!--<dynamics-->
-    <!--  damping="1.0"-->
-    <!--  friction="0" />-->
-    <mimic joint="${prefix}drive_joint" multiplier="1" offset="0" />
-  </joint>
-  <link
-    name="${prefix}left_inner_knuckle">
-    <inertial>
-      <origin
-        xyz="1.86600784687907E-06 0.0220467847633621 0.0261334672830885"
-        rpy="0 0 0" />
-      <mass
-        value="0.0230125781256706" />
-      <inertia
-        ixx="6.09490024271906E-06"
-        ixy="6.06651326160071E-11"
-        ixz="7.19102670500635E-11"
-        iyy="6.01955084375188E-06"
-        iyz="-2.75316812991721E-06"
-        izz="5.07862004479903E-06" />
-    </inertial>
-    <visual>
-      <origin
-        xyz="0 0 0"
-        rpy="0 0 0" />
-      <geometry>
-        <mesh
-          filename="package://xarm_gripper/meshes/left_inner_knuckle.STL" />
-      </geometry>
-      <material name="Silver">
-        <color rgba="0.753 0.753 0.753 1.0"/>
-      </material>
-    </visual>
-    <collision>
-      <origin
-        xyz="0 0.016 0.02"
-        rpy="-0.7 0 0" />
-      <geometry>
-        <box size="0.027 0.012 0.061"/>
-      </geometry>
-    </collision>
-  </link>
-  <joint
-    name="${prefix}left_inner_knuckle_joint"
-    type="revolute">
-    <origin
-      xyz="0 0.02 0.074098"
-      rpy="0 0 0" />
-    <parent
-      link="${prefix}xarm_gripper_base_link" />
-    <child
-      link="${prefix}left_inner_knuckle" />
-    <axis
-      xyz="1 0 0" />
-    <limit
-      lower="0"
-      upper="0.85"
-      effort="50"
-      velocity="2" />
-    <!--<dynamics-->
-    <!--  damping="1.0"-->
-    <!--  friction="0" />-->
-    <mimic joint="${prefix}drive_joint" multiplier="1" offset="0" />
-  </joint>
+        xyz="0 0.02 0.074098"
+        rpy="0 0 0"/>
+      <parent
+        link="${prefix}xarm_gripper_base_link"/>
+      <child
+        link="${prefix}left_inner_knuckle"/>
+      <axis
+        xyz="1 0 0"/>
+      <limit
+        lower="0"
+        upper="0.85"
+        effort="50"
+        velocity="2"/>
+      <!--<dynamics-->
+      <!--  damping="1.0"-->
+      <!--  friction="0" />-->
+      <mimic joint="${prefix}drive_joint" multiplier="1" offset="0"/>
+    </joint>
 
-  <xacro:if value="${loop_joints}">
-    <gazebo>
-      <joint name="${prefix}left_loop_joint" type="revolute">
-        <parent>${prefix}left_inner_knuckle</parent>
-        <child>${prefix}left_finger</child>
-        <pose>0 -0.015 0.015 0 0 0</pose>
-        <axis>
-          <xyz>1 0 0</xyz>
-          <use_parent_model_frame>false</use_parent_model_frame>
-        </axis>
-        <!--<physics>-->
-        <!--  <ode>-->
-        <!--    <implicit_spring_damper>1</implicit_spring_damper>-->
-        <!--    <cfm_damping>0</cfm_damping>-->
-        <!--    <limit>-->
-        <!--      <cfm>1e-7</cfm>-->
-        <!--      <erp>0.8</erp>-->
-        <!--    </limit>-->
-        <!--  </ode>-->
-        <!--</physics>-->
-      </joint>
-    </gazebo>
-  </xacro:if>
+    <xacro:if value="${loop_joints}">
+      <gazebo>
+        <joint name="${prefix}left_loop_joint" type="revolute">
+          <parent>${prefix}left_inner_knuckle</parent>
+          <child>${prefix}left_finger</child>
+          <pose>0 -0.015 0.015 0 0 0</pose>
+          <axis>
+            <xyz>1 0 0</xyz>
+            <use_parent_model_frame>false</use_parent_model_frame>
+          </axis>
+          <!--<physics>-->
+          <!--  <ode>-->
+          <!--    <implicit_spring_damper>1</implicit_spring_damper>-->
+          <!--    <cfm_damping>0</cfm_damping>-->
+          <!--    <limit>-->
+          <!--      <cfm>1e-7</cfm>-->
+          <!--      <erp>0.8</erp>-->
+          <!--    </limit>-->
+          <!--  </ode>-->
+          <!--</physics>-->
+        </joint>
+      </gazebo>
+    </xacro:if>
 
-  <link
-    name="${prefix}right_outer_knuckle">
-    <inertial>
+    <link
+      name="${prefix}right_outer_knuckle">
+      <inertial>
+        <origin
+          xyz="-3.1669E-14 -0.021559 0.015181"
+          rpy="0 0 0"/>
+        <mass
+          value="0.033618"/>
+        <inertia
+          ixx="1.9111E-05"
+          ixy="-1.8789E-17"
+          ixz="1.0986E-17"
+          iyy="6.6256E-06"
+          iyz="7.3008E-06"
+          izz="1.3185E-05"/>
+      </inertial>
+      <visual>
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0"/>
+        <geometry>
+          <mesh
+            filename="package://xarm_gripper/meshes/right_outer_knuckle.STL"/>
+        </geometry>
+        <material name="Silver">
+          <color rgba="0.753 0.753 0.753 1.0"/>
+        </material>
+      </visual>
+      <collision>
+        <origin
+          xyz="0 -0.015 0.02"
+          rpy="-0.48 0 0"/>
+        <geometry>
+          <box size="0.012 0.069 0.033"/>
+        </geometry>
+      </collision>
+    </link>
+    <joint
+      name="${prefix}right_outer_knuckle_joint"
+      type="revolute">
       <origin
-        xyz="-3.1669E-14 -0.021559 0.015181"
-        rpy="0 0 0" />
-      <mass
-        value="0.033618" />
-      <inertia
-        ixx="1.9111E-05"
-        ixy="-1.8789E-17"
-        ixz="1.0986E-17"
-        iyy="6.6256E-06"
-        iyz="7.3008E-06"
-        izz="1.3185E-05" />
-    </inertial>
-    <visual>
+        xyz="0 -0.035 0.059098"
+        rpy="0 0 0"/>
+      <parent
+        link="${prefix}xarm_gripper_base_link"/>
+      <child
+        link="${prefix}right_outer_knuckle"/>
+      <axis
+        xyz="-1 0 0"/>
+      <limit
+        lower="0"
+        upper="0.85"
+        effort="50"
+        velocity="2"/>
+      <!--<dynamics-->
+      <!--  damping="1.0"-->
+      <!--  friction="0" />-->
+      <mimic joint="${prefix}drive_joint" multiplier="1" offset="0"/>
+    </joint>
+    <link
+      name="${prefix}right_finger">
+      <inertial>
+        <origin
+          xyz="2.5618E-14 0.016413 0.029258"
+          rpy="0 0 0"/>
+        <mass
+          value="0.048304"/>
+        <inertia
+          ixx="1.7493E-05"
+          ixy="-5.0014E-19"
+          ixz="-7.5079E-18"
+          iyy="1.7225E-05"
+          iyz="-4.6435E-06"
+          izz="5.1466E-06"/>
+      </inertial>
+      <visual>
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0"/>
+        <geometry>
+          <mesh
+            filename="package://xarm_gripper/meshes/right_finger.STL"/>
+        </geometry>
+        <material name="Silver">
+          <color rgba="0.753 0.753 0.753 1.0"/>
+        </material>
+      </visual>
+      <collision>
+        <origin
+          xyz="0 0.0224 0.04"
+          rpy="0 0 0"/>
+        <geometry>
+          <box size="0.032 0.0072 0.042"/>
+        </geometry>
+      </collision>
+      <collision>
+        <origin
+          xyz="0 0.0154 0.036"
+          rpy="0 0 0"/>
+        <geometry>
+          <box size="0.032 0.0068 0.034"/>
+        </geometry>
+      </collision>
+      <collision>
+        <origin
+          xyz="0 0.008 0.008"
+          rpy="-0.8 0 0"/>
+        <geometry>
+          <box size="0.016 0.012 0.036"/>
+        </geometry>
+      </collision>
+    </link>
+    <joint
+      name="${prefix}right_finger_joint"
+      type="revolute">
       <origin
-        xyz="0 0 0"
-        rpy="0 0 0" />
-      <geometry>
-        <mesh
-          filename="package://xarm_gripper/meshes/right_outer_knuckle.STL" />
-      </geometry>
-      <material name="Silver">
-        <color rgba="0.753 0.753 0.753 1.0"/>
-      </material>
-    </visual>
-    <collision>
+        xyz="0 -0.035465 0.042039"
+        rpy="0 0 0"/>
+      <parent
+        link="${prefix}right_outer_knuckle"/>
+      <child
+        link="${prefix}right_finger"/>
+      <axis
+        xyz="1 0 0"/>
+      <limit
+        lower="0"
+        upper="0.85"
+        effort="50"
+        velocity="2"/>
+      <!--<dynamics-->
+      <!--  damping="1.0"-->
+      <!--  friction="0" />-->
+      <mimic joint="${prefix}drive_joint" multiplier="1" offset="0"/>
+    </joint>
+    <link
+      name="${prefix}right_inner_knuckle">
+      <inertial>
+        <origin
+          xyz="1.866E-06 -0.022047 0.026133"
+          rpy="0 0 0"/>
+        <mass
+          value="0.023013"/>
+        <inertia
+          ixx="6.0949E-06"
+          ixy="-6.0665E-11"
+          ixz="7.191E-11"
+          iyy="6.0197E-06"
+          iyz="2.7531E-06"
+          izz="5.0784E-06"/>
+      </inertial>
+      <visual>
+        <origin
+          xyz="0 0 0"
+          rpy="0 0 0"/>
+        <geometry>
+          <mesh
+            filename="package://xarm_gripper/meshes/right_inner_knuckle.STL"/>
+        </geometry>
+        <material name="Silver">
+          <color rgba="0.753 0.753 0.753 1.0"/>
+        </material>
+      </visual>
+      <collision>
+        <origin
+          xyz="0 -0.016 0.02"
+          rpy="0.7 0 0"/>
+        <geometry>
+          <box size="0.027 0.012 0.061"/>
+        </geometry>
+      </collision>
+    </link>
+    <joint
+      name="${prefix}right_inner_knuckle_joint"
+      type="revolute">
       <origin
-        xyz="0 -0.015 0.02"
-        rpy="-0.48 0 0" />
-      <geometry>
-        <box size="0.012 0.069 0.033"/>
-      </geometry>
-    </collision>
-  </link>
-  <joint
-    name="${prefix}right_outer_knuckle_joint"
-    type="revolute">
-    <origin
-      xyz="0 -0.035 0.059098"
-      rpy="0 0 0" />
-    <parent
-      link="${prefix}xarm_gripper_base_link" />
-    <child
-      link="${prefix}right_outer_knuckle" />
-    <axis
-      xyz="-1 0 0" />
-    <limit
-      lower="0"
-      upper="0.85"
-      effort="50"
-      velocity="2" />
-    <!--<dynamics-->
-    <!--  damping="1.0"-->
-    <!--  friction="0" />-->
-    <mimic joint="${prefix}drive_joint" multiplier="1" offset="0" />
-  </joint>
-  <link
-    name="${prefix}right_finger">
-    <inertial>
-      <origin
-        xyz="2.5618E-14 0.016413 0.029258"
-        rpy="0 0 0" />
-      <mass
-        value="0.048304" />
-      <inertia
-        ixx="1.7493E-05"
-        ixy="-5.0014E-19"
-        ixz="-7.5079E-18"
-        iyy="1.7225E-05"
-        iyz="-4.6435E-06"
-        izz="5.1466E-06" />
-    </inertial>
-    <visual>
-      <origin
-        xyz="0 0 0"
-        rpy="0 0 0" />
-      <geometry>
-        <mesh
-          filename="package://xarm_gripper/meshes/right_finger.STL" />
-      </geometry>
-      <material name="Silver">
-        <color rgba="0.753 0.753 0.753 1.0"/>
-      </material>
-    </visual>
-    <collision>
-      <origin
-        xyz="0 0.0224 0.04"
-        rpy="0 0 0" />
-      <geometry>
-        <box size="0.032 0.0072 0.042"/>
-      </geometry>
-    </collision>
-    <collision>
-      <origin
-        xyz="0 0.0154 0.036"
-        rpy="0 0 0" />
-      <geometry>
-        <box size="0.032 0.0068 0.034"/>
-      </geometry>
-    </collision>
-    <collision>
-      <origin
-        xyz="0 0.008 0.008"
-        rpy="-0.8 0 0" />
-      <geometry>
-        <box size="0.016 0.012 0.036"/>
-      </geometry>
-    </collision>
-  </link>
-  <joint
-    name="${prefix}right_finger_joint"
-    type="revolute">
-    <origin
-      xyz="0 -0.035465 0.042039"
-      rpy="0 0 0" />
-    <parent
-      link="${prefix}right_outer_knuckle" />
-    <child
-      link="${prefix}right_finger" />
-    <axis
-      xyz="1 0 0" />
-    <limit
-      lower="0"
-      upper="0.85"
-      effort="50"
-      velocity="2" />
-    <!--<dynamics-->
-    <!--  damping="1.0"-->
-    <!--  friction="0" />-->
-    <mimic joint="${prefix}drive_joint" multiplier="1" offset="0" />
-  </joint>
-  <link
-    name="${prefix}right_inner_knuckle">
-    <inertial>
-      <origin
-        xyz="1.866E-06 -0.022047 0.026133"
-        rpy="0 0 0" />
-      <mass
-        value="0.023013" />
-      <inertia
-        ixx="6.0949E-06"
-        ixy="-6.0665E-11"
-        ixz="7.191E-11"
-        iyy="6.0197E-06"
-        iyz="2.7531E-06"
-        izz="5.0784E-06" />
-    </inertial>
-    <visual>
-      <origin
-        xyz="0 0 0"
-        rpy="0 0 0" />
-      <geometry>
-        <mesh
-          filename="package://xarm_gripper/meshes/right_inner_knuckle.STL" />
-      </geometry>
-      <material name="Silver">
-        <color rgba="0.753 0.753 0.753 1.0"/>
-      </material>
-    </visual>
-    <collision>
-      <origin
-        xyz="0 -0.016 0.02"
-        rpy="0.7 0 0" />
-      <geometry>
-        <box size="0.027 0.012 0.061"/>
-      </geometry>
-    </collision>
-  </link>
-  <joint
-    name="${prefix}right_inner_knuckle_joint"
-    type="revolute">
-    <origin
-      xyz="0 -0.02 0.074098"
-      rpy="0 0 0" />
-    <parent
-      link="${prefix}xarm_gripper_base_link" />
-    <child
-      link="${prefix}right_inner_knuckle" />
-    <axis
-      xyz="-1 0 0" />
-    <limit
-      lower="0"
-      upper="0.85"
-      effort="0.5"
-      velocity="2" />
-    <!--<dynamics-->
-    <!--  damping="1.0"-->
-    <!--  friction="0" />-->
-    <mimic joint="${prefix}drive_joint" multiplier="1" offset="0" />
-  </joint>
+        xyz="0 -0.02 0.074098"
+        rpy="0 0 0"/>
+      <parent
+        link="${prefix}xarm_gripper_base_link"/>
+      <child
+        link="${prefix}right_inner_knuckle"/>
+      <axis
+        xyz="-1 0 0"/>
+      <limit
+        lower="0"
+        upper="0.85"
+        effort="0.5"
+        velocity="2"/>
+      <!--<dynamics-->
+      <!--  damping="1.0"-->
+      <!--  friction="0" />-->
+      <mimic joint="${prefix}drive_joint" multiplier="1" offset="0"/>
+    </joint>
 
-  <xacro:if value="${loop_joints}">
-    <gazebo>
-      <joint name="${prefix}right_loop_joint" type="revolute">
-        <parent>${prefix}right_inner_knuckle</parent>
-        <child>${prefix}right_finger</child>
-        <pose>0 0.015 0.015 0 0 0</pose>
-        <axis>
-          <xyz>1 0 0</xyz>
-          <use_parent_model_frame>false</use_parent_model_frame>
-        </axis>
-        <!--<physics>-->
-        <!--  <ode>-->
-        <!--    <implicit_spring_damper>1</implicit_spring_damper>-->
-        <!--    <cfm_damping>0</cfm_damping>-->
-        <!--    <limit>-->
-        <!--      <cfm>1e-7</cfm>-->
-        <!--      <erp>0.8</erp>-->
-        <!--    </limit>-->
-        <!--  </ode>-->
-        <!--</physics>-->
-      </joint>
-    </gazebo>
-  </xacro:if>
+    <xacro:if value="${loop_joints}">
+      <gazebo>
+        <joint name="${prefix}right_loop_joint" type="revolute">
+          <parent>${prefix}right_inner_knuckle</parent>
+          <child>${prefix}right_finger</child>
+          <pose>0 0.015 0.015 0 0 0</pose>
+          <axis>
+            <xyz>1 0 0</xyz>
+            <use_parent_model_frame>false</use_parent_model_frame>
+          </axis>
+          <!--<physics>-->
+          <!--  <ode>-->
+          <!--    <implicit_spring_damper>1</implicit_spring_damper>-->
+          <!--    <cfm_damping>0</cfm_damping>-->
+          <!--    <limit>-->
+          <!--      <cfm>1e-7</cfm>-->
+          <!--      <erp>0.8</erp>-->
+          <!--    </limit>-->
+          <!--  </ode>-->
+          <!--</physics>-->
+        </joint>
+      </gazebo>
+    </xacro:if>
 
-  <link name="${prefix}link_tcp" />
+    <link name="${prefix}link_tcp"/>
 
-  <joint
-    name="${prefix}joint_tcp"
-    type="fixed">
-    <origin
-      xyz="0 0 0.172"
-      rpy="0 0 0" />
-    <parent
-      link="${prefix}xarm_gripper_base_link" />
-    <child
-      link="${prefix}link_tcp" />
-  </joint>
+    <joint
+      name="${prefix}joint_tcp"
+      type="fixed">
+      <origin
+        xyz="0 0 0.172"
+        rpy="0 0 0"/>
+      <parent
+        link="${prefix}xarm_gripper_base_link"/>
+      <child
+        link="${prefix}link_tcp"/>
+    </joint>
 
   </xacro:macro>
 

--- a/xarm_gripper/urdf/xarm_gripper.urdf.xacro
+++ b/xarm_gripper/urdf/xarm_gripper.urdf.xacro
@@ -4,6 +4,7 @@
   Author: Jason Peng <jason@ufactory.cc>
 -->
   <xacro:arg name="use_cable_collision" default="false"/>
+  <xacro:arg name="use_slim_cable_collision" default="true"/>
   <xacro:macro name="xarm_gripper_urdf" params="prefix:='' attach_to:='' rpy:='0 0 0' xyz:='0 0 0' loop_joints:='false' ">
     <xacro:unless value="${attach_to == ''}">
       <joint name="${prefix}gripper_fix" type="fixed">
@@ -60,6 +61,24 @@
             rpy="0 0 0"/>
           <geometry>
             <box size="0.076 0.024 0.04"/>
+          </geometry>
+        </collision>
+      </xacro:if>
+      <xacro:if value="$(arg use_slim_cable_collision)">
+        <collision>
+          <origin
+            xyz="0.035 -0.025 0.025"
+            rpy="0 0 0"/>
+          <geometry>
+            <box size="0.02 0.05 0.04"/>
+          </geometry>
+        </collision>
+        <collision>
+          <origin
+            xyz="0.012 -0.055 0.025"
+            rpy="0 0 0"/>
+          <geometry>
+            <box size="0.066 0.01 0.04"/>
           </geometry>
         </collision>
       </xacro:if>

--- a/xarm_gripper/urdf/xarm_gripper.urdf.xacro
+++ b/xarm_gripper/urdf/xarm_gripper.urdf.xacro
@@ -3,6 +3,7 @@
   <!--
   Author: Jason Peng <jason@ufactory.cc>
 -->
+  <xacro:arg name="use_cable_collision" default="false"/>
   <xacro:macro name="xarm_gripper_urdf" params="prefix:='' attach_to:='' rpy:='0 0 0' xyz:='0 0 0' loop_joints:='false' ">
     <xacro:unless value="${attach_to == ''}">
       <joint name="${prefix}gripper_fix" type="fixed">
@@ -52,14 +53,16 @@
           <box size="0.053 0.1 0.1"/>
         </geometry>
       </collision>
-      <collision>
-        <origin
-          xyz="0.03 -0.062 0.025"
-          rpy="0 0 0"/>
-        <geometry>
-          <box size="0.076 0.024 0.04"/>
-        </geometry>
-      </collision>
+      <xacro:if value="$(arg use_cable_collision)">
+        <collision>
+          <origin
+            xyz="0.03 -0.062 0.025"
+            rpy="0 0 0"/>
+          <geometry>
+            <box size="0.076 0.024 0.04"/>
+          </geometry>
+        </collision>
+      </xacro:if>
     </link>
     <link
       name="${prefix}left_outer_knuckle">


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

<!-- 変更の目的 または 概要-->
## Summary
ケーブルのコリジョンを２パターン作成
argで切り替えられるように設定
ロボカップ2024までは試行錯誤的になる見込み
デフォルトではロボカップの仕様に合わせ結束バンドでケーブルを寄せた状態

<!-- このPull Requestで解決されるIssue
fix #issue番号 の形式で記述
fix以外のkeywordはこちら。(https://docs.github.com/ja/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) -->
- fix #24

<!-- 変更の詳細 -->
## Detail

<!-- この関数を変更したのでこの機能にも影響がある、など -->
## Impact

<!-- どのような動作検証を行ったか -->
## Test

<!-- ROS package向け Template

* [ ] ビルドが通った
* [ ] gazebo環境で動作した
* [ ] 実機環境で動作した
* [ ] (アプリ名)で動作検証した

-->

## Attention
<!-- 上記項目以外の補足情報など
例
- レビューをする際に見てほしい点
- ローカル環境で試す際の注意点
- このPull Requestよりも先にマージしなければならないPull Request
- 複数レビュワー指定している場合に、レビュー必須の人(いれば)の指定 -->
